### PR TITLE
build(php): Bump minimum PHP version to 8.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -19,8 +21,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '55 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -65,7 +65,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -133,7 +133,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/README.dist.md
+++ b/README.dist.md
@@ -1,9 +1,15 @@
 # JBZoo / __PACKAGE__
 
-[![CI](https://github.com/JBZoo/__PACKAGE__/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/__PACKAGE__/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/__PACKAGE__/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/__PACKAGE__?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/__PACKAGE__/coverage.svg)](https://shepherd.dev/github/JBZoo/__PACKAGE__)    [![Psalm Level](https://shepherd.dev/github/JBZoo/__PACKAGE__/level.svg)](https://shepherd.dev/github/JBZoo/__PACKAGE__)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/__PACKAGE_LOW__/badge)](https://www.codefactor.io/repository/github/jbzoo/__PACKAGE_LOW__/issues)    
-[![Stable Version](https://poser.pugx.org/jbzoo/__PACKAGE_LOW__/version)](https://packagist.org/packages/jbzoo/__PACKAGE_LOW__/)    [![Total Downloads](https://poser.pugx.org/jbzoo/__PACKAGE_LOW__/downloads)](https://packagist.org/packages/jbzoo/__PACKAGE_LOW__/stats)    [![Dependents](https://poser.pugx.org/jbzoo/__PACKAGE_LOW__/dependents)](https://packagist.org/packages/jbzoo/__PACKAGE_LOW__/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/__PACKAGE_LOW__)](https://github.com/JBZoo/__PACKAGE__/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/__PACKAGE__/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/__PACKAGE__/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/__PACKAGE__/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/__PACKAGE__?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/__PACKAGE__/coverage.svg)](https://shepherd.dev/github/JBZoo/__PACKAGE__)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/__PACKAGE__/level.svg)](https://shepherd.dev/github/JBZoo/__PACKAGE__)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/__PACKAGE__/badge)](https://www.codefactor.io/repository/github/jbzoo/__PACKAGE__/issues)
 
-
+[![Stable Version](https://poser.pugx.org/jbzoo/__PACKAGE__/version)](https://packagist.org/packages/jbzoo/__PACKAGE__/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/__PACKAGE__/downloads)](https://packagist.org/packages/jbzoo/__PACKAGE__/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/__PACKAGE__/dependents)](https://packagist.org/packages/jbzoo/__PACKAGE__/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/__PACKAGE__)](https://github.com/JBZoo/__PACKAGE__/blob/master/LICENSE)
 
 
 ### Installing

--- a/README.dist.md
+++ b/README.dist.md
@@ -4,12 +4,12 @@
 [![Coverage Status](https://coveralls.io/repos/github/JBZoo/__PACKAGE__/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/__PACKAGE__?branch=master)
 [![Psalm Coverage](https://shepherd.dev/github/JBZoo/__PACKAGE__/coverage.svg)](https://shepherd.dev/github/JBZoo/__PACKAGE__)
 [![Psalm Level](https://shepherd.dev/github/JBZoo/__PACKAGE__/level.svg)](https://shepherd.dev/github/JBZoo/__PACKAGE__)
-[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/__PACKAGE__/badge)](https://www.codefactor.io/repository/github/jbzoo/__PACKAGE__/issues)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/__PACKAGE_LOW__/badge)](https://www.codefactor.io/repository/github/jbzoo/__PACKAGE_LOW__/issues)
 
-[![Stable Version](https://poser.pugx.org/jbzoo/__PACKAGE__/version)](https://packagist.org/packages/jbzoo/__PACKAGE__/)
-[![Total Downloads](https://poser.pugx.org/jbzoo/__PACKAGE__/downloads)](https://packagist.org/packages/jbzoo/__PACKAGE__/stats)
-[![Dependents](https://poser.pugx.org/jbzoo/__PACKAGE__/dependents)](https://packagist.org/packages/jbzoo/__PACKAGE__/dependents?order_by=downloads)
-[![GitHub License](https://img.shields.io/github/license/jbzoo/__PACKAGE__)](https://github.com/JBZoo/__PACKAGE__/blob/master/LICENSE)
+[![Stable Version](https://poser.pugx.org/jbzoo/__PACKAGE_LOW__/version)](https://packagist.org/packages/jbzoo/__PACKAGE_LOW__/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/__PACKAGE_LOW__/downloads)](https://packagist.org/packages/jbzoo/__PACKAGE_LOW__/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/__PACKAGE_LOW__/dependents)](https://packagist.org/packages/jbzoo/__PACKAGE_LOW__/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/__PACKAGE_LOW__)](https://github.com/JBZoo/__PACKAGE__/blob/master/LICENSE)
 
 
 ### Installing

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php" : "^8.1"
+        "php" : "^8.2"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.1"
+        "jbzoo/toolbox-dev" : "^7.3"
     },
 
     "autoload"          : {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -16,6 +16,6 @@ declare(strict_types=1);
 
 namespace JBZoo\__NS__;
 
-class Exception extends \RuntimeException
+final class Exception extends \RuntimeException
 {
 }


### PR DESCRIPTION
- Update `composer.json` to require PHP `^8.2` and `jbzoo/toolbox-dev ^7.3`.
- Adjust GitHub Actions CI workflows to:
  - Run tests and linters against PHP 8.2, 8.3, and 8.4.
  - Remove support for PHP 8.1 from the test matrix.
  - Upgrade `actions/upload-artifact` to v4.
  - Remove the scheduled CI trigger, relying on PRs and pushes.
  - Add `contents: read` permission for improved security.